### PR TITLE
fix: adjust dart/flutter versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Downgraded minimum Dart SDK version to 3.0.0.
+* Bumped minimum Flutter version to 3.10.0.
+
 ## 1.4.0
 
 * Removed freezed and json_serializable from project

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,8 +5,8 @@ issue_tracker: https://github.com/StorybookToolkit/device_frame_plus/issues
 repository: https://github.com/StorybookToolkit/device_frame_plus
 
 environment:
-  sdk: '>=3.6.0 <4.0.0'
-  flutter: '>=3.2.0'
+  sdk: '>=3.0.0 <4.0.0'
+  flutter: '>=3.10.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
The minimum Dart SDK version was 3.6.0, which meant that minimum Flutter version was 3.27.0 according to [this table](https://docs.flutter.dev/install/archive#stable-channel).

To stay having Dart 3 as the minimum version, we need to support the lowest Flutter version that uses this version, which is 3.10 from the table.

This PR ensures that the package has no [backwards compatibility](https://github.com/widgetbook/widgetbook/actions/runs/15416900686/job/43381716350?pr=1481#step:4:11) issues.